### PR TITLE
Use asyncio sleep in shell tool

### DIFF
--- a/backend/agent/tools/sb_shell_tool.py
+++ b/backend/agent/tools/sb_shell_tool.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, Any
+import asyncio
 import time
 from uuid import uuid4
 from agentpress.tool import ToolResult, openapi_schema, xml_schema
@@ -143,10 +144,10 @@ class SandboxShellTool(SandboxToolsBase):
             
             if blocking:
                 # For blocking execution, wait and capture output
-                start_time = time.time()
-                while (time.time() - start_time) < timeout:
+                start_time = time.monotonic()
+                while (time.monotonic() - start_time) < timeout:
                     # Wait a bit before checking
-                    time.sleep(2)
+                    await asyncio.sleep(2)
                     
                     # Check if session still exists (command might have exited)
                     check_result = await self._execute_raw_command(f"tmux has-session -t {session_name} 2>/dev/null || echo 'ended'")

--- a/backend/tests/test_async_execution.py
+++ b/backend/tests/test_async_execution.py
@@ -1,0 +1,25 @@
+import asyncio
+import time
+
+async def long_running(timeout=3):
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        await asyncio.sleep(1)
+    return True
+
+async def quick_task(flag):
+    await asyncio.sleep(0.5)
+    flag.append(True)
+
+def test_async_sleep_allows_concurrency():
+    async def runner():
+        flag = []
+        long_task = asyncio.create_task(long_running(2))
+        start = time.monotonic()
+        await quick_task(flag)
+        elapsed = time.monotonic() - start
+        await long_task
+        assert elapsed < 1.5
+        assert flag == [True]
+    asyncio.run(runner())
+


### PR DESCRIPTION
## Summary
- make shell execution loop asynchronous using `asyncio.sleep`
- rely on `time.monotonic` for elapsed time checks
- add a test covering async sleep behavior

## Testing
- `pytest backend/tests/test_async_execution.py -q`