### PR TITLE
Add pluggable sandbox providers

### DIFF
--- a/backend/sandbox/providers/base.py
+++ b/backend/sandbox/providers/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class SandboxProvider(ABC):
+    """Abstract sandbox provider interface."""
+
+    @abstractmethod
+    def create(self, password: str, project_id: str | None = None) -> Any:
+        """Create a new sandbox and return a handle to it."""
+
+    @abstractmethod
+    def start(self, sandbox: Any) -> Any:
+        """Start a stopped sandbox."""
+
+    @abstractmethod
+    def get_current_sandbox(self, sandbox_id: str) -> Any:
+        """Return sandbox handle by id."""
+
+    @abstractmethod
+    def exec(self, sandbox: Any, command: str, *, session: str | None = None, async_exec: bool = False) -> Any:
+        """Execute a command inside a sandbox."""

--- a/backend/sandbox/providers/daytona_provider.py
+++ b/backend/sandbox/providers/daytona_provider.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from dotenv import load_dotenv
+from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, SessionExecuteRequest
+from daytona_api_client.models.workspace_state import WorkspaceState
+
+from utils.logger import logger
+from utils.config import config, Configuration
+from .base import SandboxProvider
+
+
+load_dotenv()
+
+
+class DaytonaProvider(SandboxProvider):
+    """Sandbox provider backed by Daytona."""
+
+    def __init__(self) -> None:
+        logger.debug("Initializing Daytona sandbox configuration")
+        daytona_config = DaytonaConfig(
+            api_key=config.DAYTONA_API_KEY,
+            server_url=config.DAYTONA_SERVER_URL,
+            target=config.DAYTONA_TARGET,
+        )
+        self.daytona = Daytona(daytona_config)
+        logger.debug("Daytona client initialized")
+
+    def create(self, password: str, project_id: str | None = None) -> Any:
+        logger.debug("Creating new Daytona sandbox environment")
+        labels = {"id": project_id} if project_id else None
+        params = CreateSandboxParams(
+            image=Configuration.SANDBOX_IMAGE_NAME,
+            public=True,
+            labels=labels,
+            env_vars={
+                "CHROME_PERSISTENT_SESSION": "true",
+                "RESOLUTION": "1024x768x24",
+                "RESOLUTION_WIDTH": "1024",
+                "RESOLUTION_HEIGHT": "768",
+                "VNC_PASSWORD": password,
+                "ANONYMIZED_TELEMETRY": "false",
+                "CHROME_PATH": "",
+                "CHROME_USER_DATA": "",
+                "CHROME_DEBUGGING_PORT": "9222",
+                "CHROME_DEBUGGING_HOST": "localhost",
+                "CHROME_CDP": "",
+            },
+            resources={"cpu": 2, "memory": 4, "disk": 5},
+        )
+        sandbox = self.daytona.create(params)
+        self._start_supervisord_session(sandbox)
+        logger.debug("Sandbox environment successfully initialized")
+        return sandbox
+
+    def start(self, sandbox: Any) -> Any:
+        self.daytona.start(sandbox)
+        return sandbox
+
+    def get_current_sandbox(self, sandbox_id: str) -> Any:
+        return self.daytona.get_current_sandbox(sandbox_id)
+
+    def exec(self, sandbox: Any, command: str, *, session: str | None = None, async_exec: bool = False) -> Any:
+        session = session or "default"
+        sandbox.process.create_session(session)
+        req = SessionExecuteRequest(command=command, var_async=async_exec)
+        return sandbox.process.execute_session_command(session, req)
+
+    def ensure_running(self, sandbox_id: str):
+        sandbox = self.daytona.get_current_sandbox(sandbox_id)
+        if sandbox.instance.state in (WorkspaceState.ARCHIVED, WorkspaceState.STOPPED):
+            self.start(sandbox)
+            # refresh after short delay
+            asyncio.sleep(0.1)
+            sandbox = self.daytona.get_current_sandbox(sandbox_id)
+            self._start_supervisord_session(sandbox)
+        return sandbox
+
+    def _start_supervisord_session(self, sandbox: Any) -> None:
+        session_id = "supervisord-session"
+        try:
+            sandbox.process.create_session(session_id)
+            sandbox.process.execute_session_command(
+                session_id,
+                SessionExecuteRequest(
+                    command=Configuration.SANDBOX_ENTRYPOINT,
+                    var_async=True,
+                ),
+            )
+        except Exception as e:
+            logger.error("Error starting supervisord session: %s", e)
+            raise

--- a/backend/sandbox/providers/e2b_provider.py
+++ b/backend/sandbox/providers/e2b_provider.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from utils.logger import logger
+from .base import SandboxProvider
+
+
+class E2BProvider(SandboxProvider):
+    """Simplified provider using the local filesystem as a sandbox."""
+
+    def __init__(self, base_path: str = "/tmp/suna-sandbox") -> None:
+        self.base_path = base_path
+        logger.warning(
+            "E2BProvider is a lightweight stub implementation. It only runs commands locally."
+        )
+
+    def create(self, password: str, project_id: str | None = None) -> Any:
+        return self.base_path
+
+    def start(self, sandbox: Any) -> Any:
+        return sandbox
+
+    def get_current_sandbox(self, sandbox_id: str) -> Any:
+        return sandbox_id
+
+    def exec(self, sandbox: Any, command: str, *, session: str | None = None, async_exec: bool = False) -> Any:
+        import subprocess
+
+        result = subprocess.run(command, shell=True, capture_output=True, text=True, cwd=self.base_path)
+        return {"stdout": result.stdout, "stderr": result.stderr, "returncode": result.returncode}

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -1,127 +1,40 @@
-from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, Sandbox, SessionExecuteRequest
-from daytona_api_client.models.workspace_state import WorkspaceState
-from dotenv import load_dotenv
+from __future__ import annotations
+
+from typing import Any
 from utils.logger import logger
 from utils.config import config
-from utils.config import Configuration
 
-load_dotenv()
+from .providers.base import SandboxProvider
+from .providers.daytona_provider import DaytonaProvider
+from .providers.e2b_provider import E2BProvider
 
-logger.debug("Initializing Daytona sandbox configuration")
-daytona_config = DaytonaConfig(
-    api_key=config.DAYTONA_API_KEY,
-    server_url=config.DAYTONA_SERVER_URL,
-    target=config.DAYTONA_TARGET
-)
+_PROVIDER_MAP = {
+    "daytona": DaytonaProvider,
+    "e2b": E2BProvider,
+    "codesandbox": DaytonaProvider,  # placeholder
+}
 
-if daytona_config.api_key:
-    logger.debug("Daytona API key configured successfully")
-else:
-    logger.warning("No Daytona API key found in environment variables")
+_provider_instance: SandboxProvider | None = None
 
-if daytona_config.server_url:
-    logger.debug(f"Daytona server URL set to: {daytona_config.server_url}")
-else:
-    logger.warning("No Daytona server URL found in environment variables")
 
-if daytona_config.target:
-    logger.debug(f"Daytona target set to: {daytona_config.target}")
-else:
-    logger.warning("No Daytona target found in environment variables")
+def get_provider() -> SandboxProvider:
+    global _provider_instance
+    if _provider_instance is None:
+        provider_name = getattr(config, "SANDBOX_PROVIDER", "daytona").lower()
+        cls = _PROVIDER_MAP.get(provider_name, DaytonaProvider)
+        _provider_instance = cls()  # type: ignore[call-arg]
+        logger.info(f"Using sandbox provider: {cls.__name__}")
+    return _provider_instance
 
-daytona = Daytona(daytona_config)
-logger.debug("Daytona client initialized")
 
-async def get_or_start_sandbox(sandbox_id: str):
-    """Retrieve a sandbox by ID, check its state, and start it if needed."""
-    
-    logger.info(f"Getting or starting sandbox with ID: {sandbox_id}")
-    
-    try:
-        sandbox = daytona.get_current_sandbox(sandbox_id)
-        
-        # Check if sandbox needs to be started
-        if sandbox.instance.state == WorkspaceState.ARCHIVED or sandbox.instance.state == WorkspaceState.STOPPED:
-            logger.info(f"Sandbox is in {sandbox.instance.state} state. Starting...")
-            try:
-                daytona.start(sandbox)
-                # Wait a moment for the sandbox to initialize
-                # sleep(5)
-                # Refresh sandbox state after starting
-                sandbox = daytona.get_current_sandbox(sandbox_id)
-                
-                # Start supervisord in a session when restarting
-                start_supervisord_session(sandbox)
-            except Exception as e:
-                logger.error(f"Error starting sandbox: {e}")
-                raise e
-        
-        logger.info(f"Sandbox {sandbox_id} is ready")
-        return sandbox
-        
-    except Exception as e:
-        logger.error(f"Error retrieving or starting sandbox: {str(e)}")
-        raise e
+def create_sandbox(password: str, project_id: str | None = None) -> Any:
+    provider = get_provider()
+    return provider.create(password, project_id)
 
-def start_supervisord_session(sandbox: Sandbox):
-    """Start supervisord in a session."""
-    session_id = "supervisord-session"
-    try:
-        logger.info(f"Creating session {session_id} for supervisord")
-        sandbox.process.create_session(session_id)
-        
-        # Execute supervisord command
-        sandbox.process.execute_session_command(session_id, SessionExecuteRequest(
-            command="exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
-            var_async=True
-        ))
-        logger.info(f"Supervisord started in session {session_id}")
-    except Exception as e:
-        logger.error(f"Error starting supervisord session: {str(e)}")
-        raise e
 
-def create_sandbox(password: str, project_id: str = None):
-    """Create a new sandbox with all required services configured and running."""
-    
-    logger.debug("Creating new Daytona sandbox environment")
-    logger.debug("Configuring sandbox with browser-use image and environment variables")
-    
-    labels = None
-    if project_id:
-        logger.debug(f"Using sandbox_id as label: {project_id}")
-        labels = {'id': project_id}
-        
-    params = CreateSandboxParams(
-        image=Configuration.SANDBOX_IMAGE_NAME,
-        public=True,
-        labels=labels,
-        env_vars={
-            "CHROME_PERSISTENT_SESSION": "true",
-            "RESOLUTION": "1024x768x24",
-            "RESOLUTION_WIDTH": "1024",
-            "RESOLUTION_HEIGHT": "768",
-            "VNC_PASSWORD": password,
-            "ANONYMIZED_TELEMETRY": "false",
-            "CHROME_PATH": "",
-            "CHROME_USER_DATA": "",
-            "CHROME_DEBUGGING_PORT": "9222",
-            "CHROME_DEBUGGING_HOST": "localhost",
-            "CHROME_CDP": ""
-        },
-        resources={
-            "cpu": 2,
-            "memory": 4,
-            "disk": 5,
-        }
-    )
-    
-    # Create the sandbox
-    sandbox = daytona.create(params)
-    logger.debug(f"Sandbox created with ID: {sandbox.id}")
-    
-    # Start supervisord in a session for new sandbox
-    start_supervisord_session(sandbox)
-    
-    logger.debug(f"Sandbox environment successfully initialized")
+async def get_or_start_sandbox(sandbox_id: str) -> Any:
+    provider = get_provider()
+    if hasattr(provider, "ensure_running"):
+        return provider.ensure_running(sandbox_id)  # type: ignore[attr-defined]
+    sandbox = provider.get_current_sandbox(sandbox_id)
     return sandbox
-

--- a/backend/sandbox/tool_base.py
+++ b/backend/sandbox/tool_base.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from agentpress.thread_manager import ThreadManager
 from agentpress.tool import Tool
-from daytona_sdk import Sandbox
+from typing import Any
 from sandbox.sandbox import get_or_start_sandbox
 from utils.logger import logger
 from utils.files_utils import clean_path
@@ -23,7 +23,7 @@ class SandboxToolsBase(Tool):
         self._sandbox_id = None
         self._sandbox_pass = None
 
-    async def _ensure_sandbox(self) -> Sandbox:
+    async def _ensure_sandbox(self) -> Any:
         """Ensure we have a valid sandbox instance, retrieving it from the project if needed."""
         if self._sandbox is None:
             try:
@@ -69,7 +69,7 @@ class SandboxToolsBase(Tool):
         return self._sandbox
 
     @property
-    def sandbox(self) -> Sandbox:
+    def sandbox(self) -> Any:
         """Get the sandbox instance, ensuring it exists."""
         if self._sandbox is None:
             raise RuntimeError("Sandbox not initialized. Call _ensure_sandbox() first.")

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -161,6 +161,7 @@ class Configuration:
     # Sandbox configuration
     SANDBOX_IMAGE_NAME = "kortix/suna:0.1.2.8"
     SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
+    SANDBOX_PROVIDER: str = "daytona"  # daytona|e2b|codesandbox
 
     @property
     def STRIPE_PRODUCT_ID(self) -> str:


### PR DESCRIPTION
## Summary
- introduce a `SandboxProvider` interface
- implement DaytonaProvider and stub E2BProvider
- choose provider via `SANDBOX_PROVIDER` config
- update sandbox helper functions and tools to use provider abstraction

## Testing
- `pytest -q`