### PR TITLE
Improve setup waiting for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The setup process includes:
 - Setting up Daytona for secure agent execution
 - Integrating with LLM providers (Anthropic, OpenAI, Groq, etc.)
 - Configuring web search and scraping capabilities
+- Waiting for Docker services to become healthy before finishing
 
 ### Quick Start
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -95,6 +95,7 @@ The wizard will:
 - Configure environment files
 - Install dependencies
 - Start Suna using your preferred method
+- Wait for Docker services to become healthy before setup completes
 
 ### 3. Supabase Configuration
 


### PR DESCRIPTION
## Summary
- wait for docker services instead of sleeping
- show progress during wait
- document waiting behavior in setup instructions

## Testing
- `python -m py_compile setup.py start.py`