### PR TITLE
Remove duplicate redis import

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -10,7 +10,6 @@ import dramatiq
 import uuid
 from agentpress.thread_manager import ThreadManager
 from services.supabase import DBConnection
-from services import redis
 from dramatiq.brokers.rabbitmq import RabbitmqBroker
 import os
 


### PR DESCRIPTION
## Summary
- delete extra redis import in `run_agent_background.py`
- lint `run_agent_background.py` with Ruff to check for unused imports

## Testing
- `ruff check backend/run_agent_background.py --select F401`